### PR TITLE
Fetch and filter media data

### DIFF
--- a/src/components/browse/searchFilters.tsx
+++ b/src/components/browse/searchFilters.tsx
@@ -114,6 +114,9 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
   const [selectedYear, setSelectedYear] = useState<number | null>(
     currentFilters.year || null,
   );
+  const [isAdult, setIsAdult] = useState<boolean>(
+    currentFilters.isAdult || false,
+  );
 
   const handleGenreToggle = (genre: string) => {
     const newGenres = selectedGenres.includes(genre)
@@ -160,6 +163,12 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
     updateFilters({ year: yearNum });
   };
 
+  const handleIsAdultChange = () => {
+    const newIsAdult = !isAdult;
+    setIsAdult(newIsAdult);
+    updateFilters({ isAdult: newIsAdult });
+  };
+
   const updateFilters = (newFilters: any) => {
     const allFilters = {
       genres: selectedGenres,
@@ -168,6 +177,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
       status: selectedStatus || undefined,
       country: selectedCountry || undefined,
       year: selectedYear,
+      isAdult: isAdult,
       ...newFilters,
     };
     // Ensure we clean up undefined values
@@ -186,6 +196,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
     setSelectedStatus("");
     setSelectedCountry("");
     setSelectedYear(null);
+    setIsAdult(false);
     onFiltersChange({
       genres: [],
       sort: "popularity",
@@ -198,7 +209,8 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
     selectedFormat ||
     selectedStatus ||
     selectedCountry ||
-    selectedYear;
+    selectedYear ||
+    isAdult;
 
   return (
     <div className="w-full">
@@ -214,7 +226,8 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
                 (selectedFormat ? 1 : 0) +
                 (selectedStatus ? 1 : 0) +
                 (selectedCountry ? 1 : 0) +
-                (selectedYear ? 1 : 0)}
+                (selectedYear ? 1 : 0) +
+                (isAdult ? 1 : 0)}
             </Badge>
           )}
         </div>
@@ -272,6 +285,16 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
               {selectedYear}
             </Badge>
           )}
+          {isAdult && (
+            <Badge 
+              variant="secondary" 
+              className="bg-red-600/80 text-white cursor-pointer"
+              onClick={handleIsAdultChange}
+            >
+              18+
+              <span className="ml-1 text-red-200">x</span>
+            </Badge>
+          )}
           <Button
             variant="outline"
             size="sm"
@@ -326,7 +349,7 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
                 </div>
 
                 {/* Right Column */}
-                <div className="grid grid-flow-col grid-cols-1 gap-4 lg:grid-rows-3">
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
 
                   <div>
                     <h3 className="mb-3 font-medium text-lg text-white">Sắp xếp</h3>
@@ -413,6 +436,22 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
                         ))}
                       </SelectContent>
                     </Select>
+                  </div>
+
+                  {/* 18+ Toggle */}
+                  <div>
+                    <h3 className="mb-3 font-medium text-lg text-white">Nội dung 18+</h3>
+                    <Button
+                      variant={isAdult ? "default" : "outline"}
+                      onClick={handleIsAdultChange}
+                      className={`w-full text-sm ${
+                        isAdult
+                          ? "bg-red-600 text-white hover:bg-red-700"
+                          : "bg-transparent text-white border-gray-600 hover:bg-red-600/20"
+                      }`}
+                    >
+                      {isAdult ? "✓ Bao gồm nội dung 18+" : "Bao gồm nội dung 18+"}
+                    </Button>
                   </div>
                 </div>
 

--- a/src/components/browse/searchFilters.tsx
+++ b/src/components/browse/searchFilters.tsx
@@ -170,6 +170,12 @@ const SearchFilters: React.FC<SearchFiltersProps> = ({
       year: selectedYear,
       ...newFilters,
     };
+    // Ensure we clean up undefined values
+    Object.keys(allFilters).forEach(key => {
+      if (allFilters[key] === undefined || allFilters[key] === "") {
+        delete allFilters[key];
+      }
+    });
     onFiltersChange(allFilters);
   };
 

--- a/src/hooks/useBrowseManga.ts
+++ b/src/hooks/useBrowseManga.ts
@@ -15,12 +15,12 @@ import useSWRInfinite from "swr/infinite";
 export interface UseBrowseOptions {
   keyword?: string;
   genres?: string[];
-  format?: MediaFormat;
+  format?: MediaFormat | string;
   limit?: number;
   tags?: string[];
   sort?: MediaSort;
   country?: string;
-  status?: MediaStatus;
+  status?: MediaStatus | string;
   isAdult?: boolean;
   year?: number;
   seasonYear?: number;
@@ -123,25 +123,41 @@ const useBrowse = (options: UseBrowseOptions) => {
       const mappedSort = sort
         ? mapSortToMediaSort(sort)
         : MediaSortEnum.Popularity;
-      const mappedFormat = type ? mapTypeToMediaFormat(type) : format;
+      
+      // Handle format mapping - prioritize format if it's a string, otherwise use type
+      let mappedFormat: MediaFormat | undefined;
+      if (format && typeof format === 'string') {
+        mappedFormat = mapTypeToMediaFormat(format);
+      } else if (type) {
+        mappedFormat = mapTypeToMediaFormat(type);
+      } else {
+        mappedFormat = format;
+      }
+      
       const mappedCountry = country ? mapCountryToMediaCountry(country) : undefined;
-      const mappedStatus = status ? mapStatusToMediaStatus(status) : undefined;
+      
+      // Handle status mapping - convert string to enum if needed
+      let mappedStatus: MediaStatus | undefined;
+      if (status && typeof status === 'string') {
+        mappedStatus = mapStatusToMediaStatus(status);
+      } else {
+        mappedStatus = status as MediaStatus | undefined;
+      }
 
-      // console.log("Fetching manga with options:", {
-      //   type: MediaType.Manga,
-      //   format: mappedFormat,
-      //   perPage: limit,
-      //   countryOfOrigin: country,
-      //   sort: [mappedSort],
-      //   status: mappedStatus,
-      //   // season: mappedSeason,
-      //   page,
-      //   ...(tags.length && { tag_in: tags }),
-      //   ...(genres.length && { genre_in: genres }),
-      //   ...(keyword && { search: keyword }),
-      //   // isAdult:
-      //   //   isAdult || genres.includes("Hentai") || genres.includes("Ecchi"),
-      // });
+      console.log("Fetching manga with options:", {
+        type: MediaType.Manga,
+        format: mappedFormat,
+        perPage: limit,
+        countryOfOrigin: mappedCountry,
+        sort: [mappedSort],
+        status: mappedStatus,
+        year: year,
+        page,
+        ...(tags.length && { tag_in: tags }),
+        ...(genres.length && { genre_in: genres }),
+        ...(keyword && { search: keyword }),
+        isAdult: isAdult || genres.includes("Hentai") || genres.includes("Ecchi"),
+      });
 
       const result = await getPageMedia({
         type: MediaType.Manga,
@@ -151,8 +167,7 @@ const useBrowse = (options: UseBrowseOptions) => {
         sort: [mappedSort],
         status: mappedStatus,
         year: year,
-        // chổ page này tôi bị undefined fix kiểu gì đây?
-        page,
+        page: page || 1,
         ...(tags.length && { tag_in: tags }),
         ...(genres.length && { genre_in: genres }),
         ...(keyword && { search: keyword }),

--- a/src/provider/Anilist/queries.ts
+++ b/src/provider/Anilist/queries.ts
@@ -70,6 +70,7 @@ query Media(
   $endDate: FuzzyDateInt
   $season: MediaSeason
   $seasonYear: Int
+  $year: Int
   $type: MediaType
   $format: MediaFormat
   $status: MediaStatus
@@ -149,6 +150,7 @@ query Media(
       endDate: $endDate
       season: $season
       seasonYear: $seasonYear
+      year: $year
       type: $type
       format: $format
       status: $status


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix year and format filters in browse functionality and improve filter handling.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The year filter was non-functional due to a missing `$year` parameter in the AniList GraphQL query. The format filter failed because the `UseBrowseOptions` interface expected an enum, but the `SearchFilters` component sent a string, coupled with an incorrect mapping logic in the `useBrowse` hook. Additionally, this PR ensures filter values are properly cleaned before being sent to the API and provides a fallback for the `page` parameter.

---

[Open in Web](https://cursor.com/agents?id=bc-18b00fbc-4ee7-4bbd-aa2a-855d7f6c215f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-18b00fbc-4ee7-4bbd-aa2a-855d7f6c215f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)